### PR TITLE
Maintain game window size when the DPI is changing.

### DIFF
--- a/Sources/Plasma/Apps/plClient/win32/plWinDpi.h
+++ b/Sources/Plasma/Apps/plClient/win32/plWinDpi.h
@@ -125,6 +125,7 @@ public:
     }
 
 private:
+    BOOL ICalcWinSize(HWND hWnd, UINT dpi, SIZE& hWndSize) const;
     void IEnableNCScaling(HWND hWnd) const;
     void IHandleDpiChange(HWND hWnd, UINT dpi, const RECT& rect) const;
 


### PR DESCRIPTION
Per Colin, on macoS, when the scale factor is changed, the game window stays the same size. This uses a window message added in Windows 10 v1703 to ensure that the game window stays the same size when the DPI changes. Unfortunately, at this time, Windows 8.1 - Windows 10 v1607 will still resize.